### PR TITLE
Extension icons, model mocks

### DIFF
--- a/extensions/src/components/extensions/README.md
+++ b/extensions/src/components/extensions/README.md
@@ -15,6 +15,7 @@ const Extensions = extensions.getByEntityId(entityId);
 
 // Access Extension attributes via .attrs
 const extensionNames = Extensions.map(Extension => Extension.attrs.name);
+const extensionIconTypes = Extensions.map(Extension => Extension.attrs.iconType);
 
 // Create extension instances
 const extInstances = Extensions

--- a/extensions/src/components/extensions/e-model/index.js
+++ b/extensions/src/components/extensions/e-model/index.js
@@ -9,15 +9,18 @@ export default [{
   VueComponent: AnalysisComponent,
   attrs: {
     name: 'Analysis',
+    iconName: 'bar-chart',
   },
 }, {
   VueComponent: ValidationsComponent,
   attrs: {
     name: 'Validations',
+    iconName: 'safety',
   },
 }, {
   VueComponent: ToolsComponent,
   attrs: {
     name: 'Tools',
+    iconName: 'tool',
   },
 }];

--- a/extensions/src/components/extensions/e-model/index.js
+++ b/extensions/src/components/extensions/e-model/index.js
@@ -9,18 +9,18 @@ export default [{
   VueComponent: AnalysisComponent,
   attrs: {
     name: 'Analysis',
-    iconName: 'bar-chart',
+    iconType: 'bar-chart',
   },
 }, {
   VueComponent: ValidationsComponent,
   attrs: {
     name: 'Validations',
-    iconName: 'safety',
+    iconType: 'safety',
   },
 }, {
   VueComponent: ToolsComponent,
   attrs: {
     name: 'Tools',
-    iconName: 'tool',
+    iconType: 'tool',
   },
 }];

--- a/extensions/src/components/extensions/e-model/validations.vue
+++ b/extensions/src/components/extensions/e-model/validations.vue
@@ -1,8 +1,6 @@
 
 <template>
-  <div>
-    <h3>Validations</h3>
-  </div>
+  <div></div>
 </template>
 
 

--- a/extensions/src/components/extensions/index.js
+++ b/extensions/src/components/extensions/index.js
@@ -3,10 +3,11 @@
  * Defines the interface between nexus-search-app and extensions
  */
 
+import get from 'lodash/get';
+
 import createExtension from '@/tools/component-wrapper';
 import nexus from '@/services/nexus';
 import http from '@/services/http';
-import get from "lodash/get"
 
 import meModelComponents from './me-model';
 import eModelComponents from './e-model';

--- a/extensions/src/components/extensions/me-model/index.js
+++ b/extensions/src/components/extensions/me-model/index.js
@@ -6,10 +6,12 @@ export default [{
   VueComponent: AnalysisComponent,
   attrs: {
     name: 'Analysis',
+    iconName: 'bar-chart',
   },
 }, {
   VueComponent: ToolsComponent,
   attrs: {
     name: 'Tools',
+    iconName: 'tool',
   },
 }];

--- a/extensions/src/components/extensions/me-model/index.js
+++ b/extensions/src/components/extensions/me-model/index.js
@@ -6,12 +6,12 @@ export default [{
   VueComponent: AnalysisComponent,
   attrs: {
     name: 'Analysis',
-    iconName: 'bar-chart',
+    iconType: 'bar-chart',
   },
 }, {
   VueComponent: ToolsComponent,
   attrs: {
     name: 'Tools',
-    iconName: 'tool',
+    iconType: 'tool',
   },
 }];

--- a/extensions/src/components/shared/analysis-component.vue
+++ b/extensions/src/components/shared/analysis-component.vue
@@ -1,7 +1,6 @@
 
 <template>
   <div>
-    <h3>Analysis Component</h3>
     <div
       v-for="analysis in analysisList"
       :key="analysis.url"
@@ -25,8 +24,8 @@
     props: ['entityId'],
     computed: {
       analysisList() {
-        // TODO replace with real data
-        return mockup[this.entityId];
+        // TODO: replace with real data
+        return mockup.eModel;
       },
     },
   };

--- a/extensions/src/components/shared/analysis-mock.json
+++ b/extensions/src/components/shared/analysis-mock.json
@@ -1,12 +1,12 @@
 
 {
-  "meModelId": [{
-    "title": "ME-Model Analaysis",
+  "meModel": [{
+    "title": "ME-Model Analysis",
     "url": "https://raw.githubusercontent.com/antonelepfl/testvue/master/imgtest/me-model-analysis.png",
     "author": "NSE"
   }],
-  "eModelId": [{
-    "title": "E-Model Analaysis",
+  "eModel": [{
+    "title": "E-Model Analysis",
     "url": "https://raw.githubusercontent.com/antonelepfl/testvue/master/imgtest/e-model-analysis.png",
     "author": "NSE"
   }]

--- a/extensions/src/tools/component-wrapper.js
+++ b/extensions/src/tools/component-wrapper.js
@@ -11,6 +11,7 @@ import Vue from 'vue';
 /**
  * @typedef {Object} ExtensionAttrs
  * @property {string} name - User friendly name of the extension
+ * @property {string} iconType - Type of the icon, see https://ant.design/components/icon/
  */
 
 function createExtension(component, defaultParams) {


### PR DESCRIPTION
* While we don't have emodel analysis and validation registered in nexus mocks will be shown.
* Add iconType extension attribute, see: https://ant.design/components/icon/

