### PR TITLE
move types fetching to middleware, enable filter types via server

### DIFF
--- a/client/components/Filters/Types/index.js
+++ b/client/components/Filters/Types/index.js
@@ -9,14 +9,6 @@ class TypesContainer extends React.Component {
   componentDidMount() {
     this.props.fetchTypes();
   }
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.query !== this.props.query ||
-      prevProps.selectedType !== this.props.selectedType
-    ) {
-      this.props.fetchTypes();
-    }
-  }
   onSelect (value) {
     this.props.updateSearchParams({ type: value });
   }

--- a/client/components/MorphologyViewer/index.js
+++ b/client/components/MorphologyViewer/index.js
@@ -78,7 +78,7 @@ class MorphologyContainer extends React.Component {
         this.viewer = new MorphoViewer(this.viewContainer);
         this.viewer.addMorphology(morphoData, {
           focusOn: true, // do we want the camera to focus on this one when it's loaded?
-          distance: 800,
+          distance: 1200,
 
           asPolyline: !!this.props.polyLine, // with polylines of with cylinders?
           // onDone: optionalCallback, // what to do when it's loaded?

--- a/client/store/actions/type-actions.js
+++ b/client/store/actions/type-actions.js
@@ -1,6 +1,7 @@
 import * as types from "./types";
 import qs from "query-string";
 import { auth } from "./index";
+import { truthy } from "@libs/utils";
 
 export default {
   fetchTypes,
@@ -13,12 +14,16 @@ export default {
 function fetchTypes() {
   return (dispatch, getState) => {
     let state = getState();
-    const { q } = state.search;
+    const { q, type, filter } = state.search;
     const { token } = state.auth;
     const { elasticSearchAPI, uiConfig } = state.config;
     const typesAPI = elasticSearchAPI + "/types";
+    let params = truthy({ q, type, filter });
+    if (params.filter) {
+      params.filter = JSON.stringify(params.filter);
+    }
     dispatch(fetchTypesStarted());
-    return fetch(typesAPI + "?" + qs.stringify({ q }), {
+    return fetch(typesAPI + "?" + qs.stringify(params), {
       headers: { Authorization: `Bearer ${token}`}
     })
       .then(response => {

--- a/client/store/middleware/searchQueryParams.js
+++ b/client/store/middleware/searchQueryParams.js
@@ -1,18 +1,32 @@
-import { facets, query } from "../actions";
-import * as types from "../actions/types";
+import { types, facets, query } from "../actions";
+import * as typeConsts from "../actions/types";
 import isEqual from "fast-deep-equal";
+import { getProp } from "@libs/utils";
 
 const routeChangingMiddleware = store => next => action => {
-  if (action.type && action.type.indexOf(types.ASSIGN_SEARCH_QUERY_PARAMS) >= 0) {
+  if (action.type && action.type.indexOf(typeConsts.ASSIGN_SEARCH_QUERY_PARAMS) >= 0) {
     const { search: currentSearchParams } = store.getState();
-    const nextSearchParams = action.payload;
+    const nextSearchParams = action.payload || {};
+    const isSameFilter = !isEqual(getProp(currentSearchParams, "filter"), getProp(nextSearchParams, "filter"));
+
+    // Update Types
+    if (
+      currentSearchParams.q !== nextSearchParams.q ||
+      !isSameFilter
+    ) {
+      store.dispatch(types.fetchTypes())
+    }
+
+    // Update facets
     if (
       currentSearchParams.q !== nextSearchParams.q ||
       currentSearchParams.type !== nextSearchParams.type ||
-      !isEqual(currentSearchParams.filter, nextSearchParam.filter)
+      !isSameFilter
     ) {
       store.dispatch(facets.fetchFacets())
     }
+
+    // Update documents
     if (
       currentSearchParams.q !== nextSearchParams.q ||
       currentSearchParams.type !== nextSearchParams.type ||

--- a/server/elastic-search/types/__snapshots__/query-builder.test.js.snap
+++ b/server/elastic-search/types/__snapshots__/query-builder.test.js.snap
@@ -9,6 +9,11 @@ Object {
       },
     },
   },
+  "query": Object {
+    "bool": Object {
+      "must": Array [],
+    },
+  },
 }
 `;
 
@@ -22,8 +27,14 @@ Object {
     },
   },
   "query": Object {
-    "query_string": Object {
-      "query": "(mySearchString* OR mySearchString~)",
+    "bool": Object {
+      "must": Array [
+        Object {
+          "query_string": Object {
+            "query": "(mySearchString* OR mySearchString~)",
+          },
+        },
+      ],
     },
   },
 }

--- a/server/elastic-search/types/normalizer.js
+++ b/server/elastic-search/types/normalizer.js
@@ -13,9 +13,12 @@ const COLOR_SETTINGS = {
  */
 function normalizer (docs) {
   let types = docs.aggregations["@types"].buckets;
-  // TODO move to client?
+  // TODO: hardcoded a count for consistency,
+  // this should absolutely be moved to client
+  // when distinct-colors npm package's browser
+  // bugs are fixed
   let palette = palettes({
-    count: types.length,
+    count: types.length > 4 ? types.length : 4,
     ...COLOR_SETTINGS
   });
   types = types.map((type, index) => {

--- a/server/elastic-search/types/query-builder.js
+++ b/server/elastic-search/types/query-builder.js
@@ -5,34 +5,76 @@ const typeAggs = {
     }
   }
 };
-
-/**
- * make a query_string es query object with a given string input
- *
- * @param {string} textQuery
- * @returns {object} an elastic search query_string object
- */
-function makeQueryStringWithText (textQuery) {
-  return {
-    query_string: {
-        query: `(${textQuery}* OR ${textQuery}~)`
-    }
-  };
-}
-
 /**
  *
  *
  * @param {string} textQuery
  * @returns {object} an elastic search query object
  */
-function makeTypeQuery({ q }={q: null}) {
+function makeTypeQuery({ q, filter }={q: null, filter: null}) {
   let params = {
+    query: {
+      bool: {
+        must: []
+      }
+    },
     aggs: typeAggs
   };
   if (q) {
-    params.query = makeQueryStringWithText(q)
+    params.query.bool.must.push({
+      query_string: {
+        query: `(${q}* OR ${q}~)`
+      }
+    });
   }
+  if (filter) {
+    filter = JSON.parse(filter);
+    // MUST is an AND, we do it for terms across filter sets
+    let must = Object.keys(filter).map(key => {
+      // SHOULD is an OR, we do it for terms in the same filter set
+      let should = filter[key].map(filterTerm => {
+        let propertyName = `${key}.raw`;
+        return { term: { [propertyName]: filterTerm } };
+      });
+
+      // For nested queries, every part of the path needs to contain
+      // its ancestors, as in "grandparent.parent.value"
+      let path = key.split(".").reduce((previous, current) => {
+        const parentLabel = previous[previous.length - 1] || null;
+        const currentLabel = parentLabel
+          ? `${parentLabel}.${current}`
+          : current;
+        previous.push(currentLabel);
+        return previous;
+      }, []);
+
+      return path.reverse().reduce((memo, level, index) => {
+        if (index === 0) {
+          memo = {
+            bool: {
+              should
+            }
+          };
+        } else {
+          memo = {
+            nested: {
+              path: level,
+              query: memo
+            }
+          };
+        }
+        return memo;
+      }, {});
+    });
+    if (must.length) {
+      params.query.bool.must.push({
+        bool: {
+          must
+        }
+      });
+    }
+  }
+
   return params;
 }
 

--- a/server/elastic-search/types/query-builder.test.js
+++ b/server/elastic-search/types/query-builder.test.js
@@ -5,9 +5,6 @@ describe("makeTypeQuery()", () => {
     expect(makeTypeQuery().aggs).toBeDefined();
   });
 
-  it("it doesn't have a query property if there are no parameters", () => {
-    expect(makeTypeQuery().query).toBeUndefined();
-  });
 
   it(" makes an elasticSearch agg object, and the proper with @types, terms, and field", () => {
     expect(makeTypeQuery()).toMatchSnapshot();


### PR DESCRIPTION
- types fetching goes to search query param middleware
- hardcoded a hard min limit of 4 colors generated by server types normalizer
- changed server types agg pattern to support filtering
- updated tests