### PR TITLE
95 update jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
                 sh "echo ${env.GIT_COMMIT}"
+                sh "echo ${commitId}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${env.GIT_COMMIT.substring(0,7)}"
+                sh "echo ${env.GIT_COMMIT}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${env.COMMIT_ID.substring(0,7)}"
+                sh "echo ${params.COMMIT_ID.substring(0,7)}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,8 +16,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${env.GIT_COMMIT}"
-                sh "echo ${commitId}"
+                sh "echo ${env.GIT_COMMIT:0:7}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,9 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${env.GIT_COMMIT:0:7}"
+                echo "${env.GIT_COMMIT}"
+                echo "${GIT_COMMIT}"
+                echo "${commitId}"
             }
         }
 
@@ -64,7 +66,7 @@ pipeline {
                 expression { !isRelease && !isPR }
             }
             steps {
-                openshiftTag srcStream: imageStream, srcTag: 'latest', destStream: imageStream, destTag: "staging,${commitId.substring(0,7)}", verbose: 'false'
+                openshiftTag srcStream: imageStream, srcTag: 'latest', destStream: imageStream, destTag: "staging,${env.GIT_COMMIT.substring(0,7)}", verbose: 'false'
             }
         }
 
@@ -73,7 +75,7 @@ pipeline {
                 expression { isRelease }
             }
             steps {
-                openshiftTag srcStream: imageStream, srcTag: 'staging', destStream: imageStream, destTag: "production,${version.substring(1)}", verbose: 'false'
+                openshiftTag srcStream: imageStream, srcTag: 'staging', destStream: imageStream, destTag: "production,${env.BRANCH_NAME.substring(1)}", verbose: 'false'
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
+                sh "echo ${commitId.substring(0,7)}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${params.COMMIT_ID.substring(0,7)}"
+                sh "echo ${env.GIT_COMMIT.substring(0,7)}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,8 +17,7 @@ pipeline {
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
                 echo "${env.GIT_COMMIT}"
-                echo "${GIT_COMMIT}"
-                echo "${commitId}"
+                echo "${GIT_COMMIT.substring(0,7)}"
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,11 +11,6 @@ pipeline {
         imageBuildName = 'search-webapp-build' 
     }
 
-    parameters {
-        string(name: 'VERSION', defaultValue: version, description: 'The tag version if any')
-        string(name: 'COMMIT_ID', defaultValue: commitId, description: 'The GIT commit ID')
-    }
-
     stages {
         stage('Start Pipeline') {
             steps{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,12 +11,17 @@ pipeline {
         imageBuildName = 'search-webapp-build' 
     }
 
+    parameters {
+        string(name: 'VERSION', defaultValue: version, description: 'The tag version if any')
+        string(name: 'COMMIT_ID', defaultValue: commitId, description: 'The GIT commit ID')
+    }
+
     stages {
         stage('Start Pipeline') {
             steps{
                 sh 'echo "Pipeline starting with environment:"'
                 sh 'printenv'
-                sh "echo ${commitId.substring(0,7)}"
+                sh "echo ${env.COMMIT_ID.substring(0,7)}"
             }
         }
 


### PR DESCRIPTION
I have fixed that bug that was crashing the Pipeline (trying to access a variable in a scope where it didn't exist). Sorry for the commit messages

We need to disable branch discovery that doesn't have a PR. We only want to build PRs, Master and Tags.