### PR TITLE
106 fix details page crash

### DIFF
--- a/client/components/Details/PageTypes/index.js
+++ b/client/components/Details/PageTypes/index.js
@@ -2,13 +2,12 @@ import IonChannel from "./IonChannel";
 import Cell from "./Cell";
 
 const detailsPageTypes = {
-  Cell,
-  IonChannel
-}
+  "nxv:SearchCell": Cell,
+  "nxv:IonChannel": IonChannel
+};
 
 export default {
-  getPageType (typeLabel="Cell", studyType="Experimental") {
-    // TODO why
+  getPageType (typeLabel, studyType) {
     typeLabel = typeLabel || "Cell";
     studyType = studyType || "Experimental";
     // TODO this value is not yet supported

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-search-webapp",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-search-webapp",
   "description": "Service which allows you to search Nexus platform",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Blue Brain Nexus",
   "license": "Apache-2.0",
   "main": "index.js",


### PR DESCRIPTION
fix an error that would crash details page because the data types have been updated as referenced [here](https://github.com/BlueBrain/nexus-search-webapp/issues/106)