### PR TITLE
252 search service tokens

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -17,7 +17,8 @@ ENV ELASTICSEARCH_CLIENT_URL="https://bbp.epfl.ch/nexus/v1/views/webapps/search/
 ENV SEARCH_API_BASE_PATH=""
 ENV STATIC_DATA_FOLDER="/usr/share/nginx/html/data"
 ENV RESOURCE_URL="https://bbp.epfl.ch/nexus/v1/resources/webapps/search/resources/"
-ENV SEARCH_APP_SERVICE_TOKEN="super-secret-token"
+ENV SEARCH_APP_SERVICE_TOKEN_PROD="super-secret-token"
+ENV SEARCH_APP_SERVICE_TOKEN_STAG="super-secret-token"
 ENV KAFKA_HOST="localhost:9092"
 ENV KAFKA_TOPIC="my-search-topic"
 CMD ["node","index.js"]

--- a/envs/dev.env.example
+++ b/envs/dev.env.example
@@ -14,8 +14,10 @@ BASE_URI="https://bbp-nexus.epfl.ch/staging"
 BASE_PATH=""
 # The base URI that the companion server will be deployed at, eg. "search.mynexus.org"
 SEARCH_API_URI="http://localhost:9999/search"
-# Service token that the backend will use to sync data
-SEARCH_APP_SERVICE_TOKEN="super-secret-token"
+# Service token that the backend will use to sync data to/from prod resources
+SEARCH_APP_SERVICE_TOKEN_PROD="super-secret-token"
+# Service token that the backend will use to sync data to/from staging resources
+SEARCH_APP_SERVICE_TOKEN_STAG="super-secret-token"
 # Kafka Host (for automatic updates)
 KAFKA_HOST="localhost:9092"
 # Search Kafka topic (the domain that the event listener must listen to)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nexus-search-webapp",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nexus-search-webapp",
   "description": "Service which allows you to search Nexus platform",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "author": "Blue Brain Nexus",
   "license": "Apache-2.0",
   "main": "index.js",

--- a/scripts/neuron-pipe/fetchResourceById.js
+++ b/scripts/neuron-pipe/fetchResourceById.js
@@ -1,9 +1,11 @@
 import { fetchWithToken } from "./helpers";
 import trimMetaData from "./trimMetaData";
+import whichToken from "../../server/libs/whichToken"
 
-export default async (doc, token, getResourceID) => {
+export default async (doc, getResourceID) => {
   try {
     let resourceID = getResourceID(doc);
+    let token = whichToken(resourceID)
     if (!resourceID) { return doc };
     let response = await fetchWithToken(resourceID, token);
     if (response) {

--- a/scripts/neuron-pipe/getResources.js
+++ b/scripts/neuron-pipe/getResources.js
@@ -1,7 +1,9 @@
 import { getInstancesList, getURIPartsFromNexusURL } from "./helpers";
 import { to } from "@libs/promise";
+import whichToken from "../../server/libs/whichToken"
 
-export default async (resourceURL, token, options={}) => {
+export default async (resourceURL, options={}) => {
+  let token = whichToken(resourceURL);
   let [base, ...uriParts] = getURIPartsFromNexusURL(resourceURL);
   const nexusRequestOptions = {
     deprecated: false,

--- a/scripts/neuron-pipe/pushToNexus.js
+++ b/scripts/neuron-pipe/pushToNexus.js
@@ -1,9 +1,11 @@
 import { fetchWithToken } from "./helpers";
 import { getProp } from "@libs/utils";
+import whichToken from "../../server/libs/whichToken"
 
-export default async (doc, token, queryURL) => {
+export default async (doc, queryURL) => {
   let body = JSON.stringify(doc);
   let error, status, responsePayload;
+  let token = whichToken(queryURL);
   [error, status, responsePayload] = await withStatus(
     fetchWithToken(queryURL, token, {
       method: "POST",

--- a/server/libs/config.js
+++ b/server/libs/config.js
@@ -9,7 +9,8 @@ let envConfig = {
   SEARCH_PROXY_PORT: process.env.SEARCH_PROXY_PORT || process.env.PORT || 8888,
   ELASTICSEARCH_CLIENT_URL: process.env.ELASTICSEARCH_CLIENT_URL || null,
   RESOURCE_URL: process.env.RESOURCE_URL || "",
-  SEARCH_APP_SERVICE_TOKEN: process.env.SEARCH_APP_SERVICE_TOKEN || "",
+  SEARCH_APP_SERVICE_TOKEN_PROD: process.env.SEARCH_APP_SERVICE_TOKEN_PROD || "",
+  SEARCH_APP_SERVICE_TOKEN_STAG: process.env.SEARCH_APP_SERVICE_TOKEN_STAG || "",
   KAFKA_HOST: process.env.KAFKA_HOST
 };
 // load ENV variables from env stage configs

--- a/server/libs/routes/sync-events.js
+++ b/server/libs/routes/sync-events.js
@@ -2,7 +2,6 @@ import syncEvents from "../../models/sync-events";
 import { to } from "../async";
 
 async function requestSomething(req, res, something) {
-  console.log("hello friends");
   let [error, docs] = await to(something(req.body))
   if (error) {
     console.log(error);

--- a/server/libs/whichToken.js
+++ b/server/libs/whichToken.js
@@ -1,0 +1,16 @@
+import config from "../libs/config";
+
+// TODO this is unfortunate, but this hardcoded provider
+// is necessary until relevant data lives in one environment
+
+const {
+  SEARCH_APP_SERVICE_TOKEN_PROD: prodToken,
+  SEARCH_APP_SERVICE_TOKEN_STAG: stagingToken
+} = config;
+
+export default function whichToken(url) {
+  if (url.indexOf("https://bbp.epfl.ch") >= 0) {
+    return prodToken
+  }
+  return stagingToken
+}

--- a/server/models/resources.js
+++ b/server/models/resources.js
@@ -1,0 +1,7 @@
+
+import * as mr from "../../scripts/neuron-pipe/resources/mr";
+
+export {
+  // Morphology Release
+  mr
+}

--- a/server/models/sync-events.js
+++ b/server/models/sync-events.js
@@ -1,11 +1,9 @@
-import { resources } from "../../scripts/neuron-pipe/consts";
-import Listen from "../libs/listen";
 import { to, waitForEach } from "@libs/promise";
-import * as resourceProcessors from "../../scripts/neuron-pipe/resources";
+import { resources } from "../../scripts/neuron-pipe/consts";
+import * as resourceProcessors from "./resources";
+import Listen from "../libs/listen";
+import whichToken from "../libs/whichToken";
 import config from "../libs/config";
-
-const token = config.SEARCH_APP_SERVICE_TOKEN;
-
 // TODO use this interface as references when creating sync resources
 // const fakeEvent = {
 //   "_createdAt": Date.now(),
@@ -93,9 +91,11 @@ export default {
     let pFactory = resourceProcessors[resource.short].processorFactory;
     let resourceURL = config.RESOURCE_URL;
     let shouldUpload = true;
+    let token = whichToken(resource.url);
+    let processor = pFactory(resource, resourceURL, shouldUpload);
     // CREATE SYNC EVENT HERE
     let id = await this.create([{ resourceShort: resource.short, ...value }]);
-    let [error, docs] = await to(waitForEach(Promise.resolve([value]), pFactory(token, resource, resourceURL, shouldUpload)));
+    let [error, docs] = await to(waitForEach(Promise.resolve([value]), processor));
     if (docs && !error) {
       // UPDATE SYNC EVENT HERE
       return await this.update(id, "fulfilled")


### PR DESCRIPTION
# What is this about?
These changes allow the search app to use *service_tokens* to exercise the Nexus v0 and v1 APIs 
This also enables the server to listen to certain events in Nexus and update the search data repository with the new or updated resource. 

It's basically an automated ETL pipe.

## caveats
Because the data we want to include in search comes from various environments at the moment, this commit contains a stop-gap solution to toggle between environment tokens when creating, reading, or updating a resource based on that resource url's base path. 

☝️This should be removed when all the data that Search needs is coming from the Nexus v1 prod environment.  