### PR TITLE
remove test data dependency in resource script

### DIFF
--- a/scripts/neuron-pipe/resources/mr.js
+++ b/scripts/neuron-pipe/resources/mr.js
@@ -4,7 +4,6 @@ import processDoc from "../processDoc";
 import fetchResourceById from "../fetchResourceById";
 import pushToNexus from "../pushToNexus";
 import flattenDownloadables from "../flattenDownloadables";
-import emtc from "../../testData/emtc.json";
 import { getProp } from "@libs/utils";
 
 export const processorFactory = (resource, resourceURL, shouldUpload) => [
@@ -20,8 +19,6 @@ export const processorFactory = (resource, resourceURL, shouldUpload) => [
     doc.cellName = {
       label: doc.name
     };
-    // get traces from trace collection (must be previously prepared)
-    doc.traces = emtc[getProp(doc, "cellName.label")];
     doc.brainLocation = {
       brainRegion: getProp(doc, "brainRegion.label")
     };


### PR DESCRIPTION
# Why this?
 Updating the search app with certain resources using the neuron-pipe script, data must first be downloaded, which is put into the testData folder. This data usually comes from other resources I know are related and can be used to enhance the target resource, but for some reason they're not connected in the knowledge graph or the query was too hard for me at the time. 

This is a solution of convenience but these resources are quite large and are not included in deployment and in git, which means the build will fail if npm tries to build without having these files. 

For now, morphology releases don't require such data, but updating other resources using the automated ETL must be done without such shortcuts, hopefully they could be done entirely through the knowledge graph. 