### PR TITLE
fix broken sh script in jenkins file to copy server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
             steps {
                 sh 'npm run build'
                 sh 'mkdir dist-client && mv dist/public dist-client && mv docker/client dist-client'
-                sh 'mkdir dist-server && mv dist/server dist-server && mv docker/server dist-server && mv package.json dist-server'
+                sh 'mkdir dist-server && cp dist/server/* dist-server && cp -r docker/server dist-server && mv package.json dist-server && mv package-lock.json dist-server'
                 sh "oc start-build ${imageBuildName} --from-dir=dist-client --follow"
                 sh "oc start-build ${serverImageBuildName} --from-dir=dist-server --follow"
             }


### PR DESCRIPTION
mv cannot be used to copy into directories that already has stuff inside. 