### PR TITLE
252 search service tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .cache/
 .DS_Store
-dist/
+
 node_modules/
 envs/*.env
 .vscode
@@ -8,3 +8,10 @@ coverage/
 .ocp-port-forwarding.js
 */**.text
 scripts/testData
+
+# dist files for build
+dist
+
+## dist files for jenkins deployment
+dist-client
+dist-server

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,8 +56,8 @@ pipeline {
             }
             steps {
                 sh 'npm run build'
-                sh 'mkdir dist-client && mv dist/public dist-client && mv docker/client dist-client'
-                sh 'mkdir dist-server && cp dist/server/* dist-server && cp -r docker/server dist-server && mv package.json dist-server && mv package-lock.json dist-server'
+                sh 'mkdir dist-client && cp dist/public/* dist-client && cp -r docker/client dist-client'
+                sh 'mkdir dist-server && cp dist/server/* dist-server && cp -r docker/server dist-server && cp package.json dist-server && cp package-lock.json dist-server'
                 sh "oc start-build ${imageBuildName} --from-dir=dist-client --follow"
                 sh "oc start-build ${serverImageBuildName} --from-dir=dist-server --follow"
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,8 +56,7 @@ pipeline {
             }
             steps {
                 sh 'npm run build'
-                sh 'mkdir dist-client && cp dist/public/* dist-client && cp -r docker/client dist-client'
-                sh 'mkdir dist-server && cp dist/server/* dist-server && cp -r docker/server dist-server && cp package.json dist-server && cp package-lock.json dist-server'
+                sh 'npm run prepare:pipeline'
                 sh "oc start-build ${imageBuildName} --from-dir=dist-client --follow"
                 sh "oc start-build ${serverImageBuildName} --from-dir=dist-server --follow"
             }

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -7,7 +7,7 @@ RUN touch /var/run/nginx.pid && chgrp 0 /var/run/nginx.pid && chmod g+rwx /var/r
 
 # Prepare nginx configuration for environment substitution at runtime
 WORKDIR /etc/nginx
-COPY docker/client/nginx.conf ./
+COPY dist-client/client/nginx.conf ./
 RUN chgrp 0 nginx.conf && chmod g+w nginx.conf
 RUN cp -a nginx.conf nginx.conf.template
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
   "homepage": "https://github.com/BlueBrain/nexus-search-webapp#readme",
   "scripts": {
     "build": "export NODE_ENV=production && parcel build server/index.js --target node --out-dir dist/server && parcel build public/index.pug --public-url ./ --out-dir dist/public && envsub --env npm_package_version dist/public/index.html",
-    "build-docker:client": "npm run build && docker build -f docker/client/Dockerfile -t ${npm_package_name}-client .",
-    "build-docker:server": "npm run build && docker build -f docker/server/Dockerfile -t ${npm_package_name}-server .",
+    "prepare:pipeline": "npm run prepare:client && npm run prepare:server",
+    "prepare:client": "mkdir dist-client && cp dist/public/* dist-client && cp -r docker/client dist-client",
+    "prepare:server": "mkdir dist-server && cp dist/server/* dist-server && cp -r docker/server dist-server && cp package.json dist-server && cp package-lock.json dist-server",
+    "build-docker:client": "npm run build && npm run prepare:client && docker build -f dist-client/client/Dockerfile -t ${npm_package_name}-client .",
+    "build-docker:server": "npm run build && npm run prepare:server && docker build -f dist-server/server/Dockerfile -t ${npm_package_name}-server .",
     "dev": "export NODE_ENV=development && ( babel-watch server/index.js --presets env --watch server/index.js & $(babel-node getenv.js) && parcel public/index.pug -p 8000 --no-cache )",
     "start": "babel-node server/index.js --presets env & parcel public/index.pug -p 8000",
     "start-docker": "docker run --rm -p 8000:8000 ${npm_package_name}",


### PR DESCRIPTION
Deployments are failing because of the single-file requirements of jenkins and some missing files during the copy process.

Copying the files, while maybe slower, is really useful for debugging and building the docker images in your own repo, so I've changed that. 
